### PR TITLE
Fix prefix drop in console color conversion

### DIFF
--- a/main.py
+++ b/main.py
@@ -655,7 +655,7 @@ def console_colors_into_span(text: str):
             if text.endswith("</span>"):
                 text = text[:-7]
                 start += "</span>"
-                final_text += start
+            final_text += start
         result = console_colors_into_span_r(text)
         text = result
     if result == "":


### PR DESCRIPTION
## Summary
- keep plain prefix text when converting console colors

## Testing
- `python3 -m py_compile main.py Bot/bot.py Bot/utils.py extensions.py`

------
https://chatgpt.com/codex/tasks/task_e_6843147b7e90832988764abb7f3a890e